### PR TITLE
Fix theme

### DIFF
--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -72,7 +72,19 @@ export const MuiCssBaseline: Components["MuiCssBaseline"] = {
   },
 }
 
+declare module "@mui/material/SvgIcon" {
+  interface SvgIconPropsSizeOverrides {
+    "x-large": true
+  }
+}
+
 export const MuiSvgIcon: Components["MuiSvgIcon"] = {
+  variants: [
+    { props: { fontSize: "small" }, style: { height: 35, width: 35 } },
+    { props: { fontSize: "medium" }, style: { height: 48, width: 48 } },
+    { props: { fontSize: "large" }, style: { height: 64, width: 64 } },
+    { props: { fontSize: "x-large" }, style: { height: 120, width: 120 } },
+  ],
   styleOverrides: {
     root: {
       display: "block",

--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -96,3 +96,11 @@ export const MuiDrawer: Components["MuiDrawer"] = {
     },
   },
 }
+
+export const MuiContainer: Components["MuiContainer"] = {
+  styleOverrides: {
+    root: {
+      paddingY: "16px",
+    },
+  },
+}

--- a/stories/IconButtons.stories.tsx
+++ b/stories/IconButtons.stories.tsx
@@ -30,7 +30,7 @@ const Template = (args: ComponentMeta<typeof SvgIcon>["args"]) => (
   <Stack gap="24px" direction="row" flexWrap="wrap">
     {Object.entries(icons).map(([name, Icon]) => (
       <IconButton>
-        <Icon color={args.color} />
+        <Icon color={args.color} fontSize="small" />
       </IconButton>
     ))}
   </Stack>

--- a/stories/Icons.stories.tsx
+++ b/stories/Icons.stories.tsx
@@ -23,13 +23,17 @@ export default {
         "text",
       ],
     },
+    fontSize: {
+      control: { type: "select" },
+      options: ["small", "medium", "large", "x-large"],
+    },
   },
 } as ComponentMeta<typeof SvgIcon>
 
 const Template = (args: ComponentMeta<typeof SvgIcon>["args"]) => (
   <Stack gap="24px" direction="row" flexWrap="wrap">
     {Object.entries(icons).map(([name, Icon]) => (
-      <Icon color={args.color} />
+      <Icon color={args.color} fontSize={args.fontSize} />
     ))}
   </Stack>
 )
@@ -37,4 +41,5 @@ const Template = (args: ComponentMeta<typeof SvgIcon>["args"]) => (
 export const Icons = Template.bind({})
 Icons.args = {
   color: "primary",
+  fontSize: "medium",
 }


### PR DESCRIPTION
Apply a default vertical padding to the `Container` component

Define allowed values for `fontSize` prop of `SvgIcon` component:
- `small`: 35x35
- `medium`: 48x48
- `large`: 64x64
- `x-large`: 120x120 