### PR TITLE
feat: Export SvgIcon, Toolbar and styled

### DIFF
--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -70,6 +70,7 @@ import StarOutline from "@mui/icons-material/StarOutline"
 import AccountTreeOutlined from "@mui/icons-material/AccountTreeOutlined"
 import WarningAmberOutlined from "@mui/icons-material/WarningAmberOutlined"
 import Warning from "@mui/icons-material/Warning"
+import Warehouse from "@mui/icons-material/Warehouse"
 
 export {
   AccountCircle,
@@ -144,4 +145,5 @@ export {
   AccountTreeOutlined,
   WarningAmberOutlined,
   Warning,
+  Warehouse,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,8 @@ import ListItemText, { ListItemTextProps } from "@mui/material/ListItemText"
 import Modal, { ModalProps } from "@mui/material/Modal"
 import Radio, { RadioProps } from "@mui/material/Radio"
 import RadioGroup, { RadioGroupProps } from "@mui/material/RadioGroup"
-import Stack from "@mui/material/Stack"
+import Stack, { StackProps } from "@mui/material/Stack"
+import SvgIcon, { SvgIconProps } from "@mui/material/SvgIcon"
 import Table, { TableProps } from "@mui/material/Table"
 import TableBody, { TableBodyProps } from "@mui/material/TableBody"
 import TableCell, { TableCellProps } from "@mui/material/TableCell"
@@ -33,7 +34,13 @@ import TableContainer, {
 } from "@mui/material/TableContainer"
 import TextField, { TextFieldProps } from "@mui/material/TextField"
 import Typography, { TypographyProps } from "@mui/material/Typography"
-import { useTheme, ThemeOptions, ThemeProvider } from "@mui/material/styles"
+import Toolbar, { ToolbarProps } from "@mui/material/Toolbar"
+import {
+  useTheme,
+  ThemeOptions,
+  ThemeProvider,
+  styled,
+} from "@mui/material/styles"
 
 export {
   Alert,
@@ -81,6 +88,9 @@ export {
   RadioGroup,
   RadioGroupProps,
   Stack,
+  StackProps,
+  SvgIcon,
+  SvgIconProps,
   Table,
   TableProps,
   TableBody,
@@ -99,7 +109,10 @@ export {
   ThemeProvider,
   Typography,
   TypographyProps,
+  Toolbar,
+  ToolbarProps,
   useTheme,
+  styled,
 }
 
 import LocalizationProvider, {

--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -174,3 +174,11 @@ export const MuiContainer: Components["MuiContainer"] = {
     },
   },
 }
+
+export const MuiToolbar: Components["MuiToolbar"] = {
+  styleOverrides: {
+    dense: {
+      minHeight: 44,
+    },
+  },
+}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -3,10 +3,12 @@ import * as typographyMobile from "./typographyMobile"
 import * as typographyDesktop from "./typographyDesktop"
 import * as palette from "./palette"
 import * as components from "./components"
+import * as mixins from "./mixins"
 
 export const mobileTheme = createTheme({
   palette,
   typography: typographyMobile,
+  mixins: mixins.mobileMixins,
   components,
 })
 

--- a/src/theme/mixins.ts
+++ b/src/theme/mixins.ts
@@ -1,0 +1,7 @@
+import { Mixins } from "@mui/material/styles/createMixins"
+
+export const mobileMixins: Mixins = {
+  toolbar: {
+    minHeight: 64,
+  },
+}

--- a/stories/SvgIcon.stories.tsx
+++ b/stories/SvgIcon.stories.tsx
@@ -1,0 +1,41 @@
+import { ComponentMeta } from "@storybook/react"
+
+import { SvgIcon } from "../src/"
+
+export default {
+  component: SvgIcon,
+  argTypes: {
+    color: {
+      control: {
+        type: "select",
+      },
+      defaultValue: "primary",
+      options: [
+        "inherit",
+        "action",
+        "disabled",
+        "primary",
+        "secondary",
+        "error",
+        "info",
+        "success",
+        "warning",
+      ],
+    },
+    fontSize: {
+      control: {
+        type: "select",
+      },
+      defaultValue: "medium",
+      options: ["inherit", "large", "medium", "small"],
+    },
+  },
+} as ComponentMeta<typeof SvgIcon>
+
+const Template = (args: ComponentMeta<typeof SvgIcon>["args"]) => (
+  <SvgIcon {...args}>
+    <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+  </SvgIcon>
+)
+
+export const svgIcon = Template.bind({})

--- a/stories/Toolbar.stories.tsx
+++ b/stories/Toolbar.stories.tsx
@@ -1,0 +1,33 @@
+import { ComponentMeta } from "@storybook/react"
+
+import { Toolbar } from "../src/index"
+
+export default {
+  component: Toolbar,
+  args: {
+    children:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+  },
+  argTypes: {
+    variant: {
+      control: {
+        type: "select",
+      },
+      options: ["dense", "regular"],
+    },
+  },
+} as ComponentMeta<typeof Toolbar>
+
+const Template = (args: ComponentMeta<typeof Toolbar>["args"]) => (
+  <Toolbar
+    {...args}
+    sx={{
+      bgcolor: "antiquewhite",
+    }}
+  />
+)
+
+export const toolbar = Template.bind({})
+toolbar.args = {
+  variant: "regular",
+}


### PR DESCRIPTION
## Pull request purpose
Rendere disponibile ad i client i componenti `SvgIcon`, `Toolbar` per la realizzazione di nuove interfacce e l'utils `styled` per stilizzare i componenti senza dover ricorrere  alla prop `sx`.
Attualmente gli stili degli applicativi mobile presentano delle `AppBar` ad altezza fissa a 64px o 44px in caso di variante dense per cui è stato modificato anche il tema del componente Toolbar nel `mobileTheme`

## What I do

- Esportato il componente `Toolbar` e l'interfaccia `ToolbarProps`
- Esportato il componente `SvgIcon` e l'interfaccia `SvgIconProps`
- Esportata la utils `styled`
- Esportato l'interfaccia `StackProps`
- Modificato il tema del componente `Toolbar` per apparire sempre con 64px di height nella variante `regular` e 44px di height nella variante `dense`

## Test

### SvgIcon.stories.tsx
![image](https://user-images.githubusercontent.com/57572328/163132981-32010ea6-81f8-4935-a531-21109fbe08c4.png)

### Toolbar.stories.tsx
![image](https://user-images.githubusercontent.com/57572328/163133224-f7b19570-d4e2-48a3-b00f-9dc6fcffdbdd.png)

