### PR TITLE
fix: change export from default to named for @mui/x-date-picker components

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,14 +188,16 @@ export {
   CheckboxProps,
 }
 
-import LocalizationProvider, {
+import {
+  LocalizationProvider,
   LocalizationProviderProps,
 } from "@mui/x-date-pickers/LocalizationProvider"
-import DesktopDatePicker, {
+import {
+  DesktopDatePicker,
   DesktopDatePickerProps,
 } from "@mui/x-date-pickers/DesktopDatePicker"
 import { DatePickerProps } from "@mui/x-date-pickers/DatePicker"
-import AdapterDateFns from "@mui/x-date-pickers/AdapterDateFns"
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns"
 
 export {
   LocalizationProvider,


### PR DESCRIPTION
[Migration from the lab](https://mui.com/x/react-date-pickers/migration-lab/)